### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sway",
-  "version": "2.0.6",
+  "version": "2.0.6-lineaje-01",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -23,9 +23,15 @@
   },
   "homepage": "https://github.com/apigee-127/sway",
   "license": "MIT",
+  "contributors": [
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
+  ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/apigee-127/sway.git"
+    "url": "https://github.com/lineaje-labs-gos/sway"
   },
   "files": [
     "dist",


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
